### PR TITLE
Create a useless user to drop incase it doesn’t exist

### DIFF
--- a/lovelace.sql
+++ b/lovelace.sql
@@ -8,7 +8,10 @@ DROP DATABASE IF EXISTS  `equipment_inventory`;
 CREATE DATABASE `equipment_inventory`;
 USE `equipment_inventory`;
 
-DROP USER IF EXISTS 'equipment_admin'@'localhost';
+# Ensure the user account exists before dropping it - MySQL in 5.5 doesn't
+# support IF EXISTS on a DROP USER
+GRANT USAGE ON *.* TO 'equipment_admin'@'localhost' IDENTIFIED BY 'password';
+DROP USER 'equipment_admin'@'localhost';
 
 # TEMP PASSWORD - MIGRATE TO SECURE SOLUTION
 CREATE USER 'equipment_admin'@'localhost' IDENTIFIED BY 'uO(W1R~W]r7,M7l7';


### PR DESCRIPTION
MySQL 5.5, which we have on our box, doesn't support the `IF EXISTS` command for `DROP USER`. This avoids that issue by creating a dummy user to drop so things stay idempotent. 